### PR TITLE
Add resume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Go script that automatically extracts all modules and videos from a Skool clas
 - Generates clean HTML pages for each module (text + video)
 - Supports all Vimeo link formats (`/video/ID`, `/ID/hash`, shared links, etc.)
 - Fully terminal-based, fast, and portable
+- Resumes gracefully: existing modules and videos are skipped
 
 ---
 


### PR DESCRIPTION
## Summary
- skip modules that already contain `module.html`
- avoid re-downloading video files that already exist
- document resumable download feature

## Testing
- `go vet ./...` *(fails: connect: no route to host)*